### PR TITLE
feat: validate route tls field

### DIFF
--- a/internal/webhook/utils/utils.go
+++ b/internal/webhook/utils/utils.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	certificateType = "CERTIFICATE"
+	privateKeyType  = "RSA PRIVATE KEY"
+)
+
+// IsTimeoutOverMax checks if the given timeout duration is over the specified maximum duration.
+// It parses the timeout string into a time.Duration and compares it with the maximum duration in seconds.
+func IsTimeoutOverMax(timeout string, maxTimeoutSeconds float64) (bool, error) {
+	duration, err := time.ParseDuration(timeout)
+	if err != nil {
+		return false, err
+	}
+
+	if duration.Seconds() > maxTimeoutSeconds {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// ValidateCert checks if the given certificate is valid and correctly formatted.
+func ValidateCert(cert string) (bool, error) {
+	certBytes, err := decodePEMBlock(cert, certificateType)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = x509.ParseCertificate(certBytes)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ValidateKey checks if the given key is valid and correctly formatted.
+func ValidateKey(key string) (bool, error) {
+	keyBytes, err := decodePEMBlock(key, privateKeyType)
+	if err != nil {
+		return false, err
+	}
+	if _, err = x509.ParsePKCS1PrivateKey(keyBytes); err == nil {
+		return true, nil
+	}
+	if _, err = x509.ParsePKCS8PrivateKey(keyBytes); err == nil {
+		return true, nil
+	}
+	if _, err = x509.ParseECPrivateKey(keyBytes); err == nil {
+		return true, nil
+	}
+	return false, errors.New("invalid private key")
+}
+
+// decodePEMBlock decodes a PEM block and validates its type.
+func decodePEMBlock(block, expectedType string) ([]byte, error) {
+	decodedBlock, _ := pem.Decode([]byte(block))
+	if decodedBlock == nil {
+		return nil, errors.New("failed to decode PEM block")
+	}
+	if decodedBlock.Type != expectedType {
+		return nil, fmt.Errorf("invalid PEM block type: got %s, want %s", decodedBlock.Type, expectedType)
+	}
+	return decodedBlock.Bytes, nil
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,8 +1,19 @@
 package webhook
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
 	"os"
 	"testing"
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +24,58 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+const (
+	certificatePlaceholder = "CERTIFICATE"
+	organization           = "Company, INC."
+	country                = "US"
+	locality               = "San Francisco"
+	privateKeyPlaceholder  = "RSA PRIVATE KEY"
+)
+
+// generateCertificate generates a self-signed certificate and returns its PEM-encoded certificate and private key.
+func generateCertificateAndPrivateKey() (certPEM []byte, privateKey []byte, err error) {
+	certificate := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject: pkix.Name{
+			Organization: []string{organization},
+			Country:      []string{country},
+			Locality:     []string{locality},
+		},
+		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1)},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(10, 0, 0),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &privKey.PublicKey, privKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBuffer := new(bytes.Buffer)
+	if err = pem.Encode(certBuffer, &pem.Block{
+		Type:  certificatePlaceholder,
+		Bytes: certBytes,
+	}); err != nil {
+		return nil, nil, err
+	}
+	privateKeyBuffer := new(bytes.Buffer)
+	if err = pem.Encode(privateKeyBuffer, &pem.Block{
+		Type:  privateKeyPlaceholder,
+		Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	return certBuffer.Bytes(), privateKeyBuffer.Bytes(), nil
+}
+
 func TestRouteWebhook(t *testing.T) {
 	webhookLog := ctrl.Log.WithName("webhook")
 	tests := []struct {
@@ -20,12 +83,18 @@ func TestRouteWebhook(t *testing.T) {
 		timeoutValue string
 		allowed      bool
 		bypass       bool
+		tls          bool
+		certificate  string
+		privateKey   string
 	}{
-		{name: "badSyntaxTimeoutRoute", timeoutValue: "1s1s", allowed: false, bypass: false},
-		{name: "badSyntaxTimeoutRoute", timeoutValue: "s", allowed: false, bypass: false},
-		{name: "badRangeTimeoutRange", timeoutValue: "1000s", allowed: false, bypass: false},
-		{name: "goodTimeoutRoute", timeoutValue: "50s", allowed: true, bypass: false},
-		{name: "bypassTest", timeoutValue: "3000s", allowed: true, bypass: true},
+		{name: "badSyntaxTimeoutRoute", timeoutValue: "1s1s", allowed: false, bypass: false, tls: false, certificate: "", privateKey: ""},
+		{name: "badSyntaxTimeoutRoute", timeoutValue: "s", allowed: false, bypass: false, tls: false, certificate: "", privateKey: ""},
+		{name: "badRangeTimeoutRange", timeoutValue: "1000s", allowed: false, bypass: false, tls: false, certificate: "", privateKey: ""},
+		{name: "goodTimeoutRoute", timeoutValue: "50s", allowed: true, bypass: false, tls: false, certificate: "", privateKey: ""},
+		{name: "bypassTest", timeoutValue: "3000s", allowed: true, bypass: true, tls: false, certificate: "", privateKey: ""},
+		{name: "goodTLS", timeoutValue: "50s", allowed: true, bypass: false, tls: true, certificate: "", privateKey: ""},
+		{name: "badTLSCertificate", timeoutValue: "50s", allowed: false, bypass: false, tls: true, certificate: "BadCertificate", privateKey: ""},
+		{name: "badTLSPrivateKey", timeoutValue: "50s", allowed: false, bypass: false, tls: true, certificate: "", privateKey: "BadPrivateKey"},
 	}
 
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}
@@ -37,10 +106,26 @@ func TestRouteWebhook(t *testing.T) {
 			g.Expect(os.Setenv(MaxTimeoutSeconds, "660")).To(Succeed())
 			decoder := admission.NewDecoder(scheme.Scheme)
 			rv := RouteValidator{Decoder: decoder, Log: webhookLog, Client: client}
+			config := &routev1.TLSConfig{}
+			if tc.tls {
+				certBytes, privateKeyBytes, err := generateCertificateAndPrivateKey()
+				if err != nil {
+					t.Errorf("Error generating certificate and private key: %v", err)
+				}
+				if tc.certificate == "" {
+					config.Certificate = string(certBytes)
+				} else {
+					config.Certificate = tc.certificate
+				}
+				if tc.privateKey == "" {
+					config.Key = string(privateKeyBytes)
+				} else {
+					config.Key = tc.privateKey
+				}
 
-			response := rv.handle(tc.timeoutValue, tc.bypass)
+			}
+			response := rv.handle(tc.timeoutValue, tc.bypass, config)
 			g.Expect(response.Allowed).Should(Equal(tc.allowed))
-
 		})
 	}
 }


### PR DESCRIPTION
With this PR, additional logic has been added to the webhook to ensure any certificates or private keys defined in the route spec are valid and correctly formatted.